### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description

This PR addresses issue #6 by adding the missing "GitHub Skills" activity to the signup page.

## Changes Made

- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Activity includes:
  - Description: "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications."
  - Schedule: "Mondays and Fridays, 3:00 PM - 4:30 PM"
  - Max participants: 25
  - Currently no participants enrolled

## Testing

The activity is now available through the `/activities` API endpoint and will appear on the signup page for students to register.

## Resolves

Closes #6

## Additional Notes

This is a high-priority issue as it was blocking students from accessing the GitHub Skills program, which is part of the GitHub Certifications initiative to help with college applications.